### PR TITLE
delete the visibility specifiers for the constructor function

### DIFF
--- a/basic/03-web3js-erc20/SimpleToken.sol
+++ b/basic/03-web3js-erc20/SimpleToken.sol
@@ -20,7 +20,7 @@ contract SimpleToken is ERC20PresetMinterPauser {
         string memory symbol,
         uint8 decimals_,
         uint256 initial_supply
-    ) public ERC20PresetMinterPauser(name, symbol) {
+    ) ERC20PresetMinterPauser(name, symbol) {
         _decimals = decimals_;
         INITIAL_SUPPLY = initial_supply * (10**uint256(decimals_));
         _mint(msg.sender, initial_supply * (10**uint256(decimals_)));


### PR DESCRIPTION
针对智能合约的构造函数，已不再需要可见限定符。
虽然加上public的限定符，编译也能通过，但像Remix等编译器都会给出告警。
这些告警信息往往也会造成初学者困扰，所以建议删除。