### PR TITLE
Update deprecated MetaMask API in task 09

### DIFF
--- a/basic/09-hardhat-react/frontend/src/components/Dapp.js
+++ b/basic/09-hardhat-react/frontend/src/components/Dapp.js
@@ -181,7 +181,7 @@ export class Dapp extends React.Component {
 
     // To connect to the user's wallet, we have to run this method.
     // It returns a promise that will resolve to the user's address.
-    const [selectedAddress] = await window.ethereum.enable()
+    const [selectedAddress] = await window.ethereum.request({ method: 'eth_requestAccounts' });
 
     // Once we have the address, we can initialize the application.
 

--- a/basic/09-hardhat-react/frontend/src/components/Dapp.js
+++ b/basic/09-hardhat-react/frontend/src/components/Dapp.js
@@ -207,7 +207,7 @@ export class Dapp extends React.Component {
     })
 
     // We reset the dapp state if the network is changed
-    window.ethereum.on('networkChanged', ([networkId]) => {
+    window.ethereum.on('chainChanged', ([_chainId]) => {
       this._stopPollingData()
       this._resetState()
     })


### PR DESCRIPTION
Initial codes produced two warnings:
```
MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.
For more information, see: https://eips.ethereum.org/EIPS/eip-1102

MetaMask: The event 'networkChanged' is deprecated and may be removed in the future. Use 'chainChanged' instead.
For more information, see: https://eips.ethereum.org/EIPS/eip-1193#chainchanged
```
This PR fixed it.