### PR TITLE
Foundry_Tool_Chain_Introduce_at_rebase_openday

### DIFF
--- a/basic/71-foundry/README.md
+++ b/basic/71-foundry/README.md
@@ -297,3 +297,5 @@ cast send <contract-address> <func-sig> <args> --rpc-url <your_rpc_url> --privat
 
 - [ds-test](https://github.com/dapphub/ds-test/blob/master/src/test.sol)
 - [The Foundry Book](https://onbjerg.github.io/foundry-book/index.html)
+- [rebase code day Reference PPT](https://learnblockchain.cn/article/3749)
+- [rebase code day Reference code base](https://github.com/bixia/solidity-dev)


### PR DESCRIPTION
add two links at the readme part, which is the PPT prepared for the rebase open day