### PR TITLE
docs: remove broken links in basic-knowledge

### DIFF
--- a/docs/basic-knowledge-en.md
+++ b/docs/basic-knowledge-en.md
@@ -3,7 +3,6 @@ Read [《Master Ethereum》](https://github.com/inoutcode/ethereum_book)Understa
 
 - Ethereum principle book: <https://ethbook.abyteahead.com/howto.html>
 - Ethereum yellow book: <https://github.com/ethereum/yellowpaper>
-- Ethereum knowledge base: <https://ethfans.org/wikis/Home>
 - Solidity learning: <https://www.bilibili.com/video/BV1St411a7Pk?p=1>
 - Learning while playing Solidity: <https://cryptozombies.io/zh/course>
 - Solidity by Example: <https://solidity-by-example.org/>

--- a/docs/basic-knowledge.md
+++ b/docs/basic-knowledge.md
@@ -6,7 +6,6 @@
 - 以太坊原理书: <https://ethbook.abyteahead.com/howto.html>
 - 以太坊黄皮书: <https://github.com/ethereum/yellowpaper>
 - web3工具集锦：<https://www.useweb3.xyz/>  
-- 以太坊知识库: <https://ethfans.org/wikis/Home>
 - Solidity 学习: <https://www.bilibili.com/video/BV1St411a7Pk?p=1>
 - 边玩边学Solidity: <https://cryptozombies.io/zh/course>
 - Solidity by Example: <https://solidity-by-example.org/>


### PR DESCRIPTION
[ethfans.org](https://ethfans.org) is no longer available.