### PR TITLE
替换 Deep Dive into Rust 链接

### DIFF
--- a/docs/basic-knowledge.md
+++ b/docs/basic-knowledge.md
@@ -10,5 +10,5 @@
 - 边玩边学Solidity: <https://cryptozombies.io/zh/course>
 - Solidity by Example: <https://solidity-by-example.org/>
 - Solidity ethernaut: <https://ethernaut.openzeppelin.com/>
-- Deep Dive into Rust: <https://itnext.io/deep-dive-into-rust-for-node-js-developers-5faace6dc71f?gi=5c0d5a41e7dd>
+- Rust 快学 <https://rq.netroby.com/01-intro/intro.html>
 - Solidity 训练计划: https://www.notion.so/Solidity-Training-Project-d1e2793ddd4a403c87e7dfe5ca1cbfc7


### PR DESCRIPTION
原文链接作者GOTO Florian 的medium 账号410，文章现在无法访问，其他地方也没有搜到英文原文，找到了该文的中文翻译进行链接替换
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/3203350/166173611-e052f048-ba00-479a-829b-d55bd4d5f893.png">

---------------

<img width="684" alt="image" src="https://user-images.githubusercontent.com/3203350/166173639-e832eac7-b380-4ef6-b6bc-6901d4fa67cc.png">
