### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/defi/Alchemix/contracts/Transmuter.sol
+++ b/defi/Alchemix/contracts/Transmuter.sol
@@ -191,7 +191,7 @@ contract Transmuter is Context {
     /// sets the length (in blocks) of one full distribution phase
     function setTransmutationPeriod(uint256 newTransmutationPeriod) public onlyGov() {
         TRANSMUTATION_PERIOD = newTransmutationPeriod;
-        emit TransmuterPeriodUpdated(TRANSMUTATION_PERIOD);
+        emit TransmuterPeriodUpdated(newTransmutationPeriod);
     }
 
     ///@dev claims the base token after it has been transmuted

--- a/defi/Alchemix/contracts/TransmuterB.sol
+++ b/defi/Alchemix/contracts/TransmuterB.sol
@@ -338,7 +338,7 @@ contract TransmuterB is Context {
     /// sets the length (in blocks) of one full distribution phase
     function setTransmutationPeriod(uint256 newTransmutationPeriod) public onlyGov() {
         transmutationPeriod = newTransmutationPeriod;
-        emit TransmuterPeriodUpdated(transmutationPeriod);
+        emit TransmuterPeriodUpdated(newTransmutationPeriod);
     }
 
     ///@dev claims the base token after it has been transmuted

--- a/defi/Alchemix/contracts/TransmuterEth.sol
+++ b/defi/Alchemix/contracts/TransmuterEth.sol
@@ -339,7 +339,7 @@ contract TransmuterEth is Context {
     /// sets the length (in blocks) of one full distribution phase
     function setTransmutationPeriod(uint256 newTransmutationPeriod) public onlyGov() {
         transmutationPeriod = newTransmutationPeriod;
-        emit TransmuterPeriodUpdated(transmutationPeriod);
+        emit TransmuterPeriodUpdated(newTransmutationPeriod);
     }
 
     ///@dev claims the base token after it has been transmuted


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.