### PR TITLE
Add Infura NFT API #957 to NFT Advanced Tasks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ You can refer to our study group's learning roadmap, which is better with the vi
 - 04. [Rarible](https://docs.rarible.org/overview/union/)
 - 05. [Zora](https://docs.zora.co/)
 - 06. [Alchemy](https://www.alchemy.com/nft-api)
+- 07. [Infura](https://www.infura.io/platform/nft-api)
 
 ## DAO advanced tasks
 


### PR DESCRIPTION
Issue:  https://github.com/Dapp-Learning-DAO/Dapp-Learning/issues/957

Add the Infura NFT API & SDK which is now in GA(General Availability)!

Query NFT data from the blockchain–in just one call.

https://www.infura.io/platform/nft-api

Reference Video: https://www.youtube.com/watch?v=FrR9bF6S_fg