### PR TITLE
fix: update foundry test codes

### DIFF
--- a/basic/41-foundry/README.md
+++ b/basic/41-foundry/README.md
@@ -278,7 +278,7 @@ interface CheatCodes {
 }
 
 contract OwnerUpOnlyTest is Test {
-  CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
+  CheatCodes cheats = CheatCodes(VM_ADDRESS);
   OwnerUpOnly upOnly;
 
   function setUp() public {


### PR DESCRIPTION
In the line 281 of the following file: https://github.com/Dapp-Learning-DAO/Dapp-Learning/blob/main/basic/41-foundry/README.md, the code ```CheatCodes(HEVM_ADDRESS)``` should be updated to ```CheatCodes(VM_ADDRESS)```, as ```HEVM_ADDRESS``` leads to ```Error (7576): Undeclared identifier.```