### PR TITLE
Fix typos in documentation and code

### DIFF
--- a/defi/Perpetual-V1/contracts/AMM.md
+++ b/defi/Perpetual-V1/contracts/AMM.md
@@ -62,7 +62,7 @@ function swapOutput(
     Dir _dir,
     Decimal.decimal memory _baseAssetAmount,
     Decimal.decimal memory _quoteAssetPoolAmount,
-    Decimal.decima l memory _baseAssetPoolAmount
+    Decimal.decimal memory _baseAssetPoolAmount
   ) external pure returns (Decimal.decimal memory);
   ```
 

--- a/defi/Perpetual-V2/subgraph/Mappings.md
+++ b/defi/Perpetual-V2/subgraph/Mappings.md
@@ -82,7 +82,7 @@ CollateralAdded 事件触发
 FundingUpdated 事件触发，每当 funding payment 更新时
 
 - `daily funding rate = (markTwap - indexTwap) / indexTwap`
-  - ?? TWAP interal = 15 minutes, 这里直接认为是 daily ??
+  - ?? TWAP interval = 15 minutes, 这里直接认为是 daily ??
 
 ## MarketRgistry
 
@@ -126,5 +126,5 @@ CollateralLiquidated 事件触发
 
 1. 新建 CollateralLiquidated 对象
 2. 更新 Trader 对象
-   - trader‘s token balance 分为 non settlement 和 setlement 两部分
+   - trader‘s token balance 分为 non settlement 和 settlement 两部分
 3. 更新 Protocol 对象，其 balance 同样分为两部分


### PR DESCRIPTION

## Changes Made:

1. defi/Perpetual-V1/contracts/AMM.md:
- Decimal.decima l memory _baseAssetPoolAmount
+ Decimal.decimal memory _baseAssetPoolAmount

2. defi/Perpetual-V2/subgraph/Mappings.md:
- ?? TWAP interal = 15 minutes
+ ?? TWAP interval = 15 minutes

3. defi/Perpetual-V2/subgraph/Mappings.md:
- trader's token balance 分为 non settlement 和 setlement 两部分
+ trader's token balance 分为 non settlement 和 settlement 两部分


**Reason**: Fixed typos, spacing issues, and incorrect technical terms in documentation and code comments for better readability and technical accuracy. No functional changes.