### PR TITLE
fix: typos in documentation files

### DIFF
--- a/defi/RAI/GEB.md
+++ b/defi/RAI/GEB.md
@@ -451,7 +451,7 @@ Relevant smart contracts:
 
 - SingleSpotDebtCeilingSetter - 这个合约通过查看 SAFEEngine 中的当前 globalDebt 来重新计算特定抵押品类型的债务上限
 
-- ESMThresholdSSetter - 这个合约通过使用 ESM 重新计算燃烧和触发结算所需的阈值
+- ESMThresholdSetter - 这个合约通过使用 ESM 重新计算燃烧和触发结算所需的阈值
 
 ## Governance Module
 

--- a/defi/RAI/PID.md
+++ b/defi/RAI/PID.md
@@ -161,7 +161,7 @@ contract PIRawPerSecondCalculator is SafeMath, SignedSafeMath {
         // newRedemptionRate cannot be lower than 10^0 (1) because of the way rpower is designed
         bool negativeOutputExceedsHundred = (boundedPIOutput < 0 && -boundedPIOutput >= int(defaultRedemptionRate));
 
-        // If it is smaller than 1, set it to the nagative rate limit
+        // If it is smaller than 1, set it to the negative rate limit
         if (negativeOutputExceedsHundred) {
           newRedemptionRate = NEGATIVE_RATE_LIMIT;
         } else {


### PR DESCRIPTION
Corrected `ESMThresholdSSetter` to `ESMThresholdSetter`
Corrected `nagative` to `negative`