### PR TITLE
Fix typos in documentation and code comments

### DIFF
--- a/basic/20-flash-loan/aave/README.md
+++ b/basic/20-flash-loan/aave/README.md
@@ -17,7 +17,7 @@ contract Flashloan is FlashLoanReceiverBase {
 }
 ```  
 
-We import the required dependence in abouve codes, the contract `Flashloan` is inherit from `FlashLoanReceiverBase` which is a abostract contract, supply several convinience functions, such as the way to repay the flash loan. The constraction function (constructor) of Flashloan.sol accept a loan pool supplier address on Aave. We will explain this later.
+We import the required dependence in abouve codes, the contract `Flashloan` is inherit from `FlashLoanReceiverBase` which is an abostract contract, supply several convinience functions, such as the way to repay the flash loan. The constraction function (constructor) of Flashloan.sol accept a loan pool supplier address on Aave. We will explain this later.
 
 ### The flashloan function  
 Well, let's take a look of flashloan function
@@ -65,7 +65,7 @@ The `executeOperation` function will be called after contract `LendingPool` get 
 
 When we triggered valid flashloan with `flashLoan` function, the all paramaters in `executeOperation` will be passed automatically, and we use `require` to make sure whether we had get the right amount of assets from flashloan.
 
-Then, we can insert any logical we want to excute. In this step, we had have all usable fund from flashloan, and we can use it to have a arbitrage.
+Then, we can insert any logical we want to excute. In this step, we had have all usable fund from flashloan, and we can use it to have an arbitrage.
 
 After we used flashloan, it's repay time.
 

--- a/basic/20-flash-loan/aavev3/README.md
+++ b/basic/20-flash-loan/aavev3/README.md
@@ -112,7 +112,7 @@ And all of this will be saved in the POOL variable, which needs to be wrapped in
 
 When we triggered valid flashloan with `flashLoan` function, the all paramaters in `executeOperation` will be passed automatically
 
-Then, we can insert any logical we want to excute. In this step, we had have all usable fund from flashloan, and we can use it to have a arbitrage.
+Then, we can insert any logical we want to excute. In this step, we had have all usable fund from flashloan, and we can use it to have an arbitrage.
 
 After we used flashloan, it's repay time.
 

--- a/basic/42-merkle-distributor-airdrop/README.md
+++ b/basic/42-merkle-distributor-airdrop/README.md
@@ -52,7 +52,7 @@ Please refer to the code: contracts/redpacket
 - ERC721LazyMintWith712  
   In the above example, we create signature with a parameter maybe friendly to machine but not that friendly to humans. Moreover, when Metamask pops up for signing we do not know what is being signed. We prefer a more structured, more readable scheme for us to see what data will be signed. EIP-712 address this point; It can display the data to be signed to user, and the generated signature will be verified by smart contract. The whole process is similiar to that in ERC721LazyMint. 
 
-  Here is a example for creating signature by EIP-712:
+  Here is an example for creating signature by EIP-712:
 
   ```js
   // Domain

--- a/dao/Mirror/readme.md
+++ b/dao/Mirror/readme.md
@@ -2,7 +2,7 @@
 + It is little step of the production on ability of Bloging, but it is a great step of Web3.
 + Cause of we can write without permission or controls and we can use NFT to get the benefit of high quality content writing but not to using hot topic to get traffic and make money from advertising.
 + So, it is a great idea.
-+ Build by a16z crypto pre partner, Denis Nazarov, he is a Developer, not only a investor, with my great respective.
++ Build by a16z crypto pre partner, Denis Nazarov, he is a Developer, not only an investor, with my great respective.
 + Mirror.xyz
 + github :[Mirror](https://github.com/mirror-xyz)
 

--- a/defi/Alchemix/contracts/libraries/alchemist/Vault.sol
+++ b/defi/Alchemix/contracts/libraries/alchemist/Vault.sol
@@ -111,14 +111,14 @@ library Vault {
     return _self.directWithdraw(_recipient, _withdrawAmount);
   }
 
-  /// @dev Adds a element to the list.
+  /// @dev Adds an element to the list.
   ///
   /// @param _element the element to add.
   function push(List storage _self, Data memory _element) internal {
     _self.elements.push(_element);
   }
 
-  /// @dev Gets a element from the list.
+  /// @dev Gets an element from the list.
   ///
   /// @param _index the index in the list.
   ///

--- a/defi/Alchemix/contracts/libraries/alchemist/VaultWithIndirection.sol
+++ b/defi/Alchemix/contracts/libraries/alchemist/VaultWithIndirection.sol
@@ -132,14 +132,14 @@ library VaultWithIndirection {
     return _self.indirectWithdraw(_recipient, _withdrawAmount);
   }
 
-  /// @dev Adds a element to the list.
+  /// @dev Adds an element to the list.
   ///
   /// @param _element the element to add.
   function push(List storage _self, Data memory _element) internal {
     _self.elements.push(_element);
   }
 
-  /// @dev Gets a element from the list.
+  /// @dev Gets an element from the list.
   ///
   /// @param _index the index in the list.
   ///


### PR DESCRIPTION
This pull request corrects various grammatical and typographical errors across multiple README files and Solidity contracts. These changes aim to improve the clarity and professionalism of the project documentation and code comments.

### Summary of Changes:

1. **README Files**:
   - Updated phrases such as "a arbitrage" to "an arbitrage" for grammatical accuracy.
   - Fixed "a example" to "an example" in the EIP-712 explanation.
   - Improved readability and fixed grammar in the DAO/Mirror README.

2. **Solidity Contracts**:
   - In `Vault.sol` and `VaultWithIndirection.sol`:
     - Corrected "a element" to "an element" in multiple comments.