### PR TITLE
Rinkeby faucet 

### DIFF
--- a/basic/27-Arbitrum-layer2/README-CN.md
+++ b/basic/27-Arbitrum-layer2/README-CN.md
@@ -60,7 +60,7 @@ https://developer.offchainlabs.com/docs/useful_addresses
   复制 .env.example 文件为 .env 文件, 然后配置其中的 PRIVATE_KEY,INFURA_ID
 
 - 转 eth 到 arbitrum 测试网络  
-  因为 arbitrum 测试网络对应的是 rinkeby, 所以需要在 rinkeby 测试网络上有测试币 , 可以通过 [rinkeby 测试网](https://faucet.rinkeby.io/) 获取测试币.  
+  因为 arbitrum 测试网络对应的是 rinkeby, 所以需要在 rinkeby 测试网络上有测试币 , 可以通过 [rinkeby 测试网](https://www.alchemy.com/faucets/ethereum-sepolia) 获取测试币.  
   之后需要把 rinkeby 测试币转移到 arbitrum 二层网络上, 可以通过 [arbitrum bridge](https://bridge.arbitrum.io/) 进行操作, 测试币转移需要等待 10 mins 左右
 
   测试币转移成功后, 通过 metaMask 可以看到在 arbitrum 上面的余额

--- a/basic/27-Arbitrum-layer2/README.md
+++ b/basic/27-Arbitrum-layer2/README.md
@@ -67,7 +67,7 @@ Retryable tickets are the Arbitrum protocol’s canonical method for passing gen
 
 - switch network to arbitrum testnet (arbitrum rinkeby)
 
-  Because the testnet is arbitrum rinkeby, so we need get some test token from ethereum rinkeby network [rinkeby 测试网](https://faucet.rinkeby.io/).
+  Because the testnet is arbitrum rinkeby, so we need get some test token from ethereum rinkeby network [rinkeby 测试网](https://www.alchemy.com/faucets/ethereum-sepolia).
 
   Then transfer ethereum rinkeby test token to arbitrum testnet through [arbitrum bridge](https://bridge.arbitrum.io/) , it will take 10mins.
 


### PR DESCRIPTION
According to Alchemy's documentation, the Rinkeby testnet was officially deprecated by the Ethereum Foundation on October 5th, 2022. The network is currently in read-only mode and will be completely sunset in Summer 2023.

The recommended migration path is to use the Sepolia testnet, which is now the preferred testing environment. This pull request updates the documentation to point users to the Sepolia faucet instead of the deprecated Rinkeby faucet, ensuring that developers have access to a supported and maintained test network.

Alchemy's documentation - https://www.alchemy.com/overviews/rinkeby-testnet