### PR TITLE
Update OpenSea Documentation Links

### DIFF
--- a/nft/opensea/readme.md
+++ b/nft/opensea/readme.md
@@ -1,6 +1,6 @@
 # OpenSea 
 
-* [opensea文档](https://docs.opensea.io/docs/1-structuring-your-smart-contract)
+* [opensea文档](https://docs.opensea.io/docs/part-1-deploy-a-smart-contract)
 * [opensea github](https://github.com/ProjectOpenSea/opensea-creatures)
 * [etherscan code](https://etherscan.io/address/0x7be8076f4ea4a4ad08075c2508e481d6c946d12b#code)
 


### PR DESCRIPTION


## Changes Made in README.md:
- Old: https://docs.opensea.io/docs/1-structuring-your-smart-contract
- New: https://docs.opensea.io/docs/part-1-deploy-a-smart-contract

## Reason for Changes:
OpenSea has reorganized their documentation structure. The old link is deprecated and returns a 404 error. The new link points to the current maintained documentation containing the same information but in an updated format. This change ensures users have access to the latest documentation and prevents broken links.

The update aligns with OpenSea's official documentation restructuring and maintains documentation relevance for users.