### PR TITLE
fix: a mistake fix of `feeGrowthOutside` initialization in 'understandV3Whitepaper.md'

### DIFF
--- a/defi/Uniswap-V3/whitepaperGuide/understandV3Witepaper.md
+++ b/defi/Uniswap-V3/whitepaperGuide/understandV3Witepaper.md
@@ -420,8 +420,8 @@ feeGrowthInside = feeGrowthGlobal - feeGrowthOutside_below - feeGrowthOutside_ab
 
 每当有流动性注入的时候，在价格的边界对应的 tick 上有如下初始化规则：
 
-- 当 `i_current < i` 则 `feeGrowthOutside = fee_global`
-- 当 `i_current >= i` 则 `feeGrowthOutside = 0`
+- 当 `i_current < i` 则 `feeGrowthOutside = 0`
+- 当 `i_current >= i` 则 `feeGrowthOutside = fee_global`
 
 在交易过程中，`feeGrowthOutside` 有如下更新规则：
 


### PR DESCRIPTION
The piecewise function in the chapter "不同区间之间的分配" mentions the rules of `feeGrowthOutside` initialization. I discovered that the formula given in the chapter is the exact opposite of the formula shown in the whitepaper of Uniswap V3(i.e., formula 6.21).

The assumption of `feeGrowthOutside` in the whitepaper is described as follows: "When 𝑓𝑜 is initialized for a tick 𝑖, the value—by convention—is chosen as if all of the fees earned to date had occurred below that tick".
This means `fee_global` ought to be at the left side of the tick which is going to be initialized. Therefore, when `i_current` is greater than or equal to `i`, the 'outside' under this case is the left side of the tick(the value of `feeGrowthOutside` should be `fee_global` instead of `0`). I swapped the two values in the piecewise function to correct the mistake currently shown.