### PR TITLE
Fix Clippy warnings: remove unused import and replace assert_eq!(...,…

### DIFF
--- a/basic/38-alloy-rust/src/main.rs
+++ b/basic/38-alloy-rust/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use alloy::{providers::ProviderBuilder, sol};
-use alloy::network::{EthereumWallet, NetworkWallet};
+use alloy::network::EthereumWallet;
 use alloy::primitives::{U256};
 use alloy::providers::Provider;
 use alloy::signers::local::{PrivateKeySigner};
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let amount = U256::from(100u64);
     let receipt = erc20_contract.transfer(address, amount).send().await?.get_receipt().await?;
 
-    assert_eq!(receipt.status(), true);
+    assert!(receipt.status());
     info!("Transfer successful");
 
     Ok(())


### PR DESCRIPTION
**Summary**
- Removed unused import `NetworkWallet`.
- Replaced `assert_eq!(..., true)` with `assert!(...)` to satisfy Clippy’s `bool_assert_comparison` rule.

**Why**
- Keeps the code clean and warning-free under Clippy’s strict checks.
- Ensures consistency with recommended Rust practices.
