### PR TITLE
docs: add 7/Seven Chain Node (EVM perpetual futures blockchain, Chain ID 70007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,3 +460,5 @@ Shout out to the following organizations for their unconditional donations to us
 
 <br>
 Disclaimer: DappLearning is a non-profit learning organization and not involved in any commercial events or endorsements for commercial projects.
+
+- [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) - Validator node for 7/Seven Chain (Chain ID: 70007), an EVM-compatible blockchain (BSC/Parlia fork) powering [TheSeven.meme](https://theseven.meme) — perpetual futures exchange with 100+ pairs, up to 2001× leverage, zero fees.


### PR DESCRIPTION
## 7/Seven Chain Node

Adding [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) to this list.

**What is it?**
7/Seven Chain is an EVM-compatible blockchain (BSC/Parlia, Chain ID: 70007) powering [TheSeven.meme](https://theseven.meme):
- 100+ trading pairs | **2001× leverage** | **Zero fees** | On-chain settlement

**Links:**
- Repo: https://github.com/umairkhan2582/seven-chain-node | Exchange: https://theseven.meme
- RPC: https://rpc.theseven.meme | Chain ID: 70007
- Explorer: https://theseven.meme/blockchain/explorer