### PR TITLE
docs: Update Gnosis Safe docs URLs in dao/Gnosis chapter

### DIFF
--- a/dao/Gnosis/Gnosis Safe Analysis 2.md
+++ b/dao/Gnosis/Gnosis Safe Analysis 2.md
@@ -13,7 +13,7 @@
 
 `ModuleManager`合约里比较有意思的一点是它使用了一个`map(address=>address)`形成的链表将所有的Modules串起来，并设置了一个哨兵模块`address(1)`作为链表头部。
 
-在网站上添加Module的步骤可以参考如下链接：https://help.gnosis-safe.io/en/articles/4934427-add-a-module
+在网站上添加Module的步骤可以参考如下链接：https://help.safe.global/
 
 ### 模块管理合约-`ModuleManager`
 

--- a/dao/Gnosis/Gnosis Safe Analysis02.md
+++ b/dao/Gnosis/Gnosis Safe Analysis02.md
@@ -13,7 +13,7 @@
 
 `ModuleManager`合约里比较有意思的一点是它使用了一个`map(address=>address)`形成的链表将所有的Modules串起来，并设置了一个哨兵模块`address(1)`作为链表头部。
 
-在网站上添加Module的步骤可以参考如下链接：https://help.gnosis-safe.io/en/articles/4934427-add-a-module
+在网站上添加Module的步骤可以参考如下链接：https://help.safe.global/
 
 ### 模块管理合约-`ModuleManager`
 

--- a/dao/Gnosis/readme.md
+++ b/dao/Gnosis/readme.md
@@ -2,5 +2,5 @@
 
 
 ## 参考链接
-gnosis文档： https://docs.gnosis-safe.io/clients/third-party-frontends
+gnosis文档： https://docs.safe.global/getting-started/clients
 gnosis github: https://github.com/gnosis


### PR DESCRIPTION
Hi Dapp-Learning-DAO maintainers,

Small housekeeping PR for the Gnosis chapter (`dao/Gnosis/`). Safe (formerly Gnosis Safe) rebranded in July 2022 and migrated its docs from `docs.gnosis-safe.io` to `docs.safe.global`. The legacy `help.gnosis-safe.io` subdomain is now DNS-dead (broken link).

Three URLs updated across three files:

- `docs.gnosis-safe.io/clients/third-party-frontends` → `docs.safe.global/getting-started/clients` (closest equivalent)
- `help.gnosis-safe.io/en/articles/4934427-add-a-module` → `help.safe.global/` (root, article ID was not preserved in help-center migration)

The chapter title "Gnosis Safe Analysis" and all educational prose are intentionally left unchanged. The intent is to fix the broken/redirected URLs without rewriting the historical content.

Samuel Akpan
Safe Foundation
